### PR TITLE
Allow single quotes for literals

### DIFF
--- a/ptsd/lexer.py
+++ b/ptsd/lexer.py
@@ -48,7 +48,7 @@ class Lexer(object):
     t.lexer.lineno += len(t.value)
 
   def t_LITERAL(self, t):
-    r'\"([^\\\n]|(\\.))*?\"'
+    r'[\"\']([^\\\n]|(\\.))*?[\"\']'
     t.value = Literal(t.value[1:-1])  # strip off ""s
     return t
 


### PR DESCRIPTION
Right now ptsd only supports double quotes for string literals. [Thrift language specification](https://thrift.apache.org/docs/idl#literal) supports both double and single quotes.