### PR TITLE
extends should be ast.Identifier not LexerIdentifier

### DIFF
--- a/ptsd/parser.py
+++ b/ptsd/parser.py
@@ -262,7 +262,7 @@ class Parser(object):
   def p_extends(self, p):
     '''extends : EXTENDS IDENTIFIER
                | empty'''
-    p[0] = p[2] if p[1] else None
+    p[0] = Identifier(p, 2) if p[1] else None
 
   def p_function_list(self, p):
     '''function_list : function_list function

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.2.0'
+version = '0.2.1'
 
 
 setup(


### PR DESCRIPTION
when use ptsd

```
f = open('./tutorial/tutorial.thrift', 'r')                                                                               
tree = Parser().parse(f.read())
print(tree)
```
to parse apache tutorial thrift https://github.com/apache/thrift/tree/master/tutorial  it will print

```
service Calculator extends <ptsd.lexer.Identifier object at 0x1080d2eb0> {
  void ping()
  ...
}
```
service.extends is still a `LexerIdentifier`, not a `ast.Identifier` (yes, no need to add a `Extends` Node)
